### PR TITLE
make-static-dispatch: Don't replace eql with * in specializers

### DIFF
--- a/src/sbcl.lisp
+++ b/src/sbcl.lisp
@@ -37,8 +37,7 @@
   "Optimization policy at which static dispatching is performed.")
 
 (defun make-static-dispatch (name lambda-list specializers)
-  (let ((specializers (substitute '* 'eql specializers :key #'ensure-car))
-        (type-list (lambda-list->type-list lambda-list specializers))
+  (let ((type-list (lambda-list->type-list lambda-list specializers))
         (required (parse-ordinary-lambda-list lambda-list)))
 
     (with-gensyms (node args types)


### PR DESCRIPTION
I'm not sure why eql is being replaced with * in `make-static-dispatch`. If it is not replaced, https://github.com/alex-gutev/generic-cl/issues/12 is fixed. All tests pass of both `static-dispatch` as well as `generic-cl`.